### PR TITLE
Implements printing GT911 configuration register block

### DIFF
--- a/lv_port_indev.c
+++ b/lv_port_indev.c
@@ -20,6 +20,7 @@
 /*********************
  *      DEFINES
  *********************/
+#define PRINT_GT911_CONFIG // Prints device configuration after initialization. Comment out to disable printing.
 
 /**********************
  *      TYPEDEFS
@@ -100,6 +101,22 @@ int gt911_i2c_read(uint8_t slave_addr, uint16_t register_addr, uint8_t *data_buf
  * Touchpad
  * -----------------*/
 
+/*Prints GT911 configuration block*/
+#if defined(PRINT_GT911_CONFIG)
+static void print_config(void)
+{
+    uint8_t config[GT911_CFG_END_ADDRESS - GT911_CFG_BASE_ADDRESS + 1] = { 0 };
+    gt911_i2c_read(gt911_status.i2c_dev_addr, GT911_CFG_BASE_ADDRESS, config, sizeof(config));
+
+    printf("device configuration from 0x%04hX to 0x%04hX:\n", GT911_CFG_BASE_ADDRESS, GT911_CFG_END_ADDRESS);
+    for(int idx = 1; idx <= sizeof(config); idx++)
+    {
+        printf("%02hhX ", config[idx - 1]);
+        if(0 == (idx % 6)) { printf(": 0x%04hX - 0x%04hX\n", GT911_CFG_BASE_ADDRESS + idx - 6, GT911_CFG_BASE_ADDRESS + idx - 1); }
+    }
+}
+#endif
+
 /*Initialize your touchpad*/
 static void touchpad_init(void)
 {
@@ -137,6 +154,10 @@ static void touchpad_init(void)
         gt911_i2c_read(gt911_status.i2c_dev_addr, GT911_Y_COORD_RES_H, &data_buf, 1);
         gt911_status.max_y_coord |= ((uint16_t)data_buf << 8);
         gt911_status.inited = true;
+
+#if defined(PRINT_GT911_CONFIG)
+        static void print_config(void);
+#endif
     }
 }
 

--- a/lv_port_indev.h
+++ b/lv_port_indev.h
@@ -26,9 +26,14 @@ extern "C" {
 /**********************
  *      TYPEDEFS
  **********************/
-#define GT911_I2C_SLAVE_ADDR   0x5D
+#define GT911_I2C_SLAVE_ADDR          0x5D
 
-#define GT911_PRODUCT_ID_LEN   4
+#define GT911_PRODUCT_ID_LEN          4
+/* Configuration Register Map of GT911; R/W registers */
+#define GT911_CFG_BASE_ADDRESS        0x8047 // first configuration register
+#define GT911_CFG_CHECKSUM            0x80FF // configuration CRC of 0x8047 to 0x80fE
+#define GT911_CFG_FRESH               0x8100 // config update flag; written by host when config shall be activated/stored persistently
+#define GT911_CFG_END_ADDRESS         0x8100 // last configuration register
 
 /* Register Map of GT911 */
 #define GT911_PRODUCT_ID1             0x8140
@@ -44,11 +49,11 @@ extern "C" {
 #define GT911_VENDOR_ID               0x814A
 
 #define GT911_STATUS_REG              0x814E
-#define GT911_STATUS_REG_BUF        0x80
-#define GT911_STATUS_REG_LARGE      0x40
-#define GT911_STATUS_REG_PROX_VALID 0x20
-#define GT911_STATUS_REG_HAVEKEY    0x10
-#define GT911_STATUS_REG_PT_MASK    0x0F
+#define GT911_STATUS_REG_BUF          0x80
+#define GT911_STATUS_REG_LARGE        0x40
+#define GT911_STATUS_REG_PROX_VALID   0x20
+#define GT911_STATUS_REG_HAVEKEY      0x10
+#define GT911_STATUS_REG_PT_MASK      0x0F
 
 #define GT911_TRACK_ID1               0x814F
 #define GT911_PT1_X_COORD_L           0x8150


### PR DESCRIPTION
This PR implements printing the whole GT911 configuration block.
- relates to https://github.com/geeekpi/pico_breadboard_kit/issues/1

Example output:

```bash
device configuration from 0x8047 to 0x8100:
98 E0 01 40 01 05 : 0x8047 - 0x804C
0C 20 01 08 28 05 : 0x804D - 0x8052
50 3C 0F 05 00 00 : 0x8053 - 0x8058
...
00 00 00 00 00 00 : 0x80F5 - 0x80FA
00 00 00 00 5C 00 : 0x80FB - 0x8100
```