### PR TITLE
Adds fixed pin information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pico_breakboard_kit
+# pico_breadboard_kit
 ## Description
-This is Full Demo Code for Pico Breakboard Kit with 3.5" TFT Capacitive Touch Screen
+This is Full Demo Code for Pico Breadboard Kit with 3.5" TFT Capacitive Touch Screen
 ## TFT Features
 * Resolution: 320x480 Pixels
 * Screen IC: ST7796SU1
@@ -9,27 +9,30 @@ This is Full Demo Code for Pico Breakboard Kit with 3.5" TFT Capacitive Touch Sc
 * TFT screen communication protocol: SPI (SPI0)
 * TFT Capacitive touch screen communication protocol: I2C (I2C0 SDA: GP8, SCL: GP9)
 ## Pinout 
-| Components | Pinout|
-|---|---|
-| Buzzer | GP13 |
-| LEDs | D1: GP16, D2: GP17, D3: 3V3, D4: 5V |
-| RGB LED| GP12|
-| Joystick| X-axis: ADC0, Y-axis: ADC1 
-|Button | BTN1: GP15, BTN2: GP14|
+| Components | Pinout                              |
+|------------|-------------------------------------|
+| Buzzer     | GP13                                |
+| LEDs       | D1: GP16, D2: GP17, D3: 3V3, D4: 5V |
+| RGB LED    | GP12                                |
+| Joystick   | X-axis: ADC0, Y-axis: ADC1          |
+| Button     | BTN1: GP15, BTN2: GP14              |
 
 ### TFT screen Pinout
 |Raspberry Pi Pico | 3.5 TFT Screen |
-|---|---|
-| GP2 | CLK |
-| GP3 | DIN |
-| GP5 | CS |
-| GP6 | DC |
-| GP7 | RST |
+|------------------|----------------|
+| GP2              | CLK            |
+| GP3              | MOSI           |
+| GP4              | MISO           |
+| GP5              | CS             |
+| GP6              | DC             |
+| GP7              | RST            |
 ### Touch Screen Pinout
 |Raspberry Pi Pico | Capacitive Touch screen |
-|---|---|
-| I2C0 SDA GP8 | SDA |
-| I2C0 SCL GP9 | SCL |
+|------------------|-------------------------|
+| I2C0 SDA GP8     | SDA                     |
+| I2C0 SCL GP9     | SCL                     |
+| GP10             | RST                     |
+| GP11             | INT                     |
 
 ## Getting Start
 * Install Pico-SDK in Raspberry Pi 
@@ -72,12 +75,12 @@ sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-n
 * Download Repository 
 ```bash
 cd /home/pi/
-git clone --recursive https://github.com/geeekpi/pico_breakboard_kit.git
+git clone --recursive https://github.com/geeekpi/pico_breadboard_kit.git
 ```
 
 * Build Projects
 ```bash
-cd pico_breakboard_kit/
+cd pico_breadboard_kit/
 mkdir build
 cd build/
 cmake --no-warn-unused-cli -DPICO_OPTIMIZED_DEBUG=1 -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCMAKE_BUILD_TYPE:STRING=Debug ../

--- a/lv_port_disp.c
+++ b/lv_port_disp.c
@@ -10,6 +10,7 @@
  *      INCLUDES
  *********************/
 #include "lv_port_disp.h"
+#include <pico/binary_info.h>
 #include <stdbool.h>
 
 #include "pico/stdlib.h"
@@ -223,6 +224,11 @@ static void disp_init(void)
 		{0, {0}, 0xff},
 	};
 
+    bi_decl_if_func_used(bi_program_feature("TFT 480x320 (SPI0)"))
+    bi_decl_if_func_used(bi_3pins_with_func(gpio_clk, gpio_din, gpio_cs, GPIO_FUNC_SPI))
+    bi_decl_if_func_used(bi_4pins_with_names(gpio_clk, "TFT (SCLK)", gpio_din, "TFT (MOSI)", 4, "TFT (MISO)", gpio_cs, "TFT (CS)")) 
+    bi_decl_if_func_used(bi_2pins_with_names(gpio_dc, "TFT (DC)", gpio_rst, "TFT (RST)"))
+    
     spi_init(spi0, 62.5 * 1000 * 1000);
     spi_set_format(spi0, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
 

--- a/lv_port_indev.c
+++ b/lv_port_indev.c
@@ -15,6 +15,7 @@
 #include "hardware/i2c.h"
 #include "hardware/gpio.h"
 
+#include <pico/binary_info.h>
 #include <stdio.h>
 
 /*********************
@@ -108,6 +109,11 @@ static void touchpad_init(void)
         gt911_status.i2c_dev_addr = GT911_I2C_SLAVE_ADDR;
         uint8_t data_buf;
 
+        bi_decl_if_func_used(bi_program_feature("Capacitive Touch (I2C0)"))
+        bi_decl_if_func_used(bi_2pins_with_func(8, 9, GPIO_FUNC_I2C))
+        bi_decl_if_func_used(bi_2pins_with_names(8, "Touch", 9, "Touch"))
+        bi_decl_if_func_used(bi_2pins_with_names(10, "RST, Touch", 11, "INT, Touch"))
+      
         i2c_init(i2c0, 100 * 1000);
         gpio_set_function(8 /* SDA */, GPIO_FUNC_I2C);
         gpio_set_function(9 /* SCL */, GPIO_FUNC_I2C);

--- a/main.c
+++ b/main.c
@@ -120,6 +120,8 @@ static void hw_handler(lv_event_t *e)
         vTaskDelay(100 / portTICK_PERIOD_MS);
 
         // 蜂鸣器
+        bi_decl_if_func_used(bi_program_feature("Buzzer"))
+        bi_decl_if_func_used(bi_1pin_with_name(13, "Buzzer"))
         gpio_init(13);
         gpio_set_dir(13, GPIO_OUT);
 
@@ -155,11 +157,17 @@ static void hw_handler(lv_event_t *e)
         // todo get free sm
         PIO pio = pio0;
         int sm = 0;
+        
+        bi_decl_if_func_used(bi_program_feature("RGB LED 1x (WS2012, PIO0)"));
+        bi_decl_if_func_used(bi_1pin_with_func(12, GPIO_FUNC_PIO0));
+        bi_decl_if_func_used(bi_1pin_with_name(12, "RGB LED"));
+    
         uint offset = pio_add_program(pio, &ws2812_program);
-
         ws2812_program_init(pio, sm, offset, 12, 800000, true);
         put_pixel(urgb_u32(0, 0, 0));
 
+        bi_decl_if_func_used(bi_program_feature("User Buttons"))
+        bi_decl_if_func_used(bi_2pins_with_names(15, "Button 1", 14, "Button 2"))
         gpio_set_irq_enabled_with_callback(14, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &gpio_callback);
         gpio_set_irq_enabled_with_callback(15, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &gpio_callback);
         gpio_set_irq_enabled_with_callback(22, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, true, &gpio_callback);
@@ -176,6 +184,10 @@ static void hw_handler(lv_event_t *e)
 
         lv_led_off(led2);
 
+        bi_decl_if_func_used(bi_program_feature("USER LEDs (2x)"))
+        bi_decl_if_func_used(bi_1pin_with_name(16, "LED1 (blue)"))
+        bi_decl_if_func_used(bi_1pin_with_name(17, "LED2 (blue)"))
+    
         gpio_init(16);
         gpio_init(17);
 
@@ -237,6 +249,9 @@ void task0(void *pvParam)
         if (adc_en)
         {
             adc_init();
+            bi_decl_if_func_used(bi_program_feature("Joystick 2-axis (ADC0, ADC1)"))
+            bi_decl_if_func_used(bi_1pin_with_name(26, "X-axis (ADC0)"))
+            bi_decl_if_func_used(bi_1pin_with_name(27, "Y-axis (ADC1)"))
             // Make sure GPIO is high-impedance, no pullups etc
             adc_gpio_init(26);
             adc_gpio_init(27);


### PR DESCRIPTION
This PR declares binary information of several  I/O Pins:
- LEDs
- RGB LED
- buzzer
- TFT SPI pins
- touch I2C pins
- buttons
- joystick (analogue in)

PR relates to
- https://github.com/geeekpi/pico_breadboard_kit/issues/2
- and adds missing info about pins `4: TFT (MISO)` , `10: RST, Touch` and `11: INT, Touch`.

The information can be simply recalled by `picotool` as follows:

```bash
picotool info -a foo.elf
File foo.elf:

Program Information
 name:          foo
 version:       0.1
...
 features:      TFT 480x320 (SPI0)
                Capacitive Touch (I2C0)
                Joystick 2-axis (ADC0, ADC1)
                RGB LED 1x (WS2012, PIO0)
                UART stdin / stdout
...
Fixed Pin Information
 0:   UART0 TX
 1:   UART0 RX
 2:   SPI0 SCK, TFT (SCLK)
 3:   SPI0 TX, TFT (MOSI)
 4:   TFT (MISO)
 5:   SPI0 CSn, TFT (CS)
 6:   TFT (DC)
 7:   TFT (RST)
 8:   I2C0 SDA, Touch
 9:   I2C0 SCL, Touch
 10:  RST, Touch
 11:  INT, Touch
 12:  PIO0, RGB LED
 26:  X-axis (ADC0)
 27:  Y-axis (ADC1)
...
```
